### PR TITLE
Create index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=https://juliamolsim.github.io/Molly.jl/dev/" />
+  </head>
+
+  <body>
+    <p><a href="https://juliamolsim.github.io/Molly.jl/dev/">Redirect</a></p>
+  </body>
+</html>


### PR DESCRIPTION
This file will redirect the default GitHub pages link to the dev documentation. Right now if you click the GitHub Pages link on the main GitHub page it does not work.